### PR TITLE
Fixed up the transforms

### DIFF
--- a/dns2proxy.py
+++ b/dns2proxy.py
@@ -599,7 +599,7 @@ def std_A_qry(msg, prov_ip):
             host2 = ''
             for from_host in transformation.keys():
                 if host.startswith(from_host):
-                    host2 = transformation[from_host]
+                    host2 = transformation[from_host]+host.split(from_host)[1]
                     break
             if host2 != '':
                 DEBUGLOG('SSLStrip transforming host: %s => %s ...' % (host, host2))

--- a/transform.cfg
+++ b/transform.cfg
@@ -1,6 +1,6 @@
 #Transformation file
-wwww.:www
-social.:www
+wwww.:www.
+social.:www.
 web:
 cuentas:accounts
 gmail:mail


### PR DESCRIPTION
While upgrading to the new dns2proxy for the mana toolkit, I noticed that the essential HSTS transform functionality had been broken. I fixed it by making the transform.cfg config actually transform the result, not just replace it.